### PR TITLE
Improve when closing New Task dialog without content

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -45,13 +45,13 @@ export class AppComponent {
     const dialogRef = this.dialog.open(TaskDialogComponent, {
       width: '270px',
       data: {
-        task: {},
+        task: null,
       },
     });
     dialogRef
       .afterClosed()
       .subscribe((result: TaskDialogResult) => {
-        if (!result) {
+        if (!result?.task) {
           return;
         }
         this.todo.push(result.task);
@@ -75,7 +75,7 @@ export class AppComponent {
       if (result.delete) {
         dataList.splice(taskIndex, 1);
       } else {
-        dataList[taskIndex] = task;
+        dataList[taskIndex] = result.task;
       }
     });
   }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -28,7 +28,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule } from '@angular/material/dialog';
 import { TaskDialogComponent } from './task-dialog/task-dialog.component';
 import { MatInputModule } from '@angular/material/input';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [AppComponent, TaskComponent, TaskDialogComponent],
@@ -42,7 +42,8 @@ import { FormsModule } from '@angular/forms';
     MatDialogModule,
     MatInputModule,
     FormsModule,
-    BrowserAnimationsModule
+    BrowserAnimationsModule,
+    ReactiveFormsModule
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/src/app/task-dialog/task-dialog.component.html
+++ b/src/app/task-dialog/task-dialog.component.html
@@ -13,19 +13,19 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
+<mat-dialog-content [formGroup]="form">
+  <mat-form-field>
+    <mat-label>Title</mat-label>
+    <input matInput cdkFocusInitial formControlName="title" required />
+  </mat-form-field>
 
-<mat-form-field>
-  <mat-label>Title</mat-label>
-  <input matInput cdkFocusInitial [(ngModel)]="data.task.title" />
-</mat-form-field>
-
-<mat-form-field>
-  <mat-label>Description</mat-label>
-  <textarea matInput [(ngModel)]="data.task.description"></textarea>
-</mat-form-field>
-
+  <mat-form-field>
+    <mat-label>Description</mat-label>
+    <textarea matInput formControlName="description"></textarea>
+  </mat-form-field>
+</mat-dialog-content>
 <div mat-dialog-actions>
-  <button mat-button [mat-dialog-close]="{ task: data.task }">OK</button>
+  <button mat-button [mat-dialog-close]="{ task: form.value }" [disabled]="!form.valid">OK</button>
   <button mat-button (click)="cancel()">Cancel</button>
   <button
     *ngIf="data.enableDelete"

--- a/src/app/task-dialog/task-dialog.component.ts
+++ b/src/app/task-dialog/task-dialog.component.ts
@@ -15,6 +15,7 @@
  */
 
 import { Component, Inject } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { Task } from '../task/task';
 
@@ -24,22 +25,27 @@ import { Task } from '../task/task';
   styleUrls: ['./task-dialog.component.css'],
 })
 export class TaskDialogComponent {
-  private backupTask: Partial<Task> = { ...this.data.task };
+  form = new FormGroup({
+    title: new FormControl('', Validators.required),
+    description: new FormControl('')
+  });
 
   constructor(
     public dialogRef: MatDialogRef<TaskDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: TaskDialogData
-  ) {}
+  ) {
+    if (data.task) {
+      this.form.patchValue(data.task);
+    }
+  }
 
   cancel(): void {
-    this.data.task.title = this.backupTask.title;
-    this.data.task.description = this.backupTask.description;
     this.dialogRef.close(this.data);
   }
 }
 
 export interface TaskDialogData {
-  task: Partial<Task>;
+  task: Partial<Task> | null;
   enableDelete: boolean;
 }
 


### PR DESCRIPTION
Hey, thanks a lot for the tutorial! I've just noticed a minor issue: 

**Overview**
When user clicks on the "New Task" button and then cancels the dialog, an empty task is automatically added to the Backlog.
**Screenshot**
 ![cancel-new-task-dialog](https://user-images.githubusercontent.com/44652232/145058862-0e05c59a-0474-43e2-8980-211ef8d8759b.gif)
**Cause**
When  empty task is passed to the `data` property of the dialog configuration object it gets assigned to the private `backupTask` property in `TaskDialogComponent` so when `cancel` method is called  the `this.backupTask.title` and `this.backupTask.description` are set to `undefined`.
Which passes the `if (!result)` check in `AppComponent` where we subscribe to the `afterClosed()` observable in `newTask()` method.

**Solution 1**
Add an additional check for `null` or `undefined` for `title` and `description`  in `newTask()` method
```javascript
dialogRef
      .afterClosed()
      .subscribe((result: TaskDialogResult) => {
        if (!result  || !result.task?.title || !result.task?.description) {
          return;
        }...
```
**Solution 2**
These are my "50 cents" :D on how it might be implemented. We can  pass `task: null` in `newTask()` method and set up a `FormGroup` with empty task and description controls for new tasks. And  in dialog constructor we can patch it to the form if it's not `null` or `undefined` (in case of edit dialog double click).

Have a nice day!